### PR TITLE
Update Django .gitignore entries

### DIFF
--- a/data/custom/Django.gitignore
+++ b/data/custom/Django.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 __pycache__/
 local_settings.py
+media
+db.sqlite3


### PR DESCRIPTION
Default output of `python manage.py startproject` sets a default sqlite file called `db.sqlite3`. This should be ignored in git and shouldn't be replicated across different developers and deploy environments.

Also, ignores the `media` directory which is a common place to put uploaded files in.
